### PR TITLE
There is no space between multiple categories on the blog post

### DIFF
--- a/packages/base/src/components/Meta.js
+++ b/packages/base/src/components/Meta.js
@@ -28,7 +28,7 @@ const Meta = props => {
           {categories.map(category => {
             const link = (
               <Link key={category} to={`/categories/${category}`}>
-                {category}
+                <span>{category}</span>
               </Link>
             );
             const txt = <span key={category}>{category}</span>;

--- a/packages/clean-diary/src/components/Meta.js
+++ b/packages/clean-diary/src/components/Meta.js
@@ -33,7 +33,7 @@ const Meta = props => {
           {categories.map(category => {
             const link = (
               <Link key={category} to={`/categories/${category}`}>
-                {category}
+                <span>{category}</span>
               </Link>
             );
             const txt = <span key={category}>{category}</span>;

--- a/packages/default/src/components/Meta.js
+++ b/packages/default/src/components/Meta.js
@@ -30,7 +30,7 @@ const Meta = props => {
           {categories.map(category => {
             const link = (
               <Link key={category} to={`/categories/${category}`}>
-                {category}
+                <span>{category}</span>
               </Link>
             );
             const txt = <span key={category}>{category}</span>;


### PR DESCRIPTION
Problem: There is no space between multiple categories
Solution: Fixing the space between multiple categories with span tag

There is no space between tags 'test', 'alfa', 'beta'

![image](https://user-images.githubusercontent.com/83388/49587609-5e6ffa00-f98a-11e8-9057-c730e78dd252.png)

After the fix
![image](https://user-images.githubusercontent.com/83388/49587669-8fe8c580-f98a-11e8-838c-56e70bf36f5e.png)
